### PR TITLE
chore(build): Share tsup config helpers

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup'
+import { outExtensionMjsCjs } from '../../scripts/tsup/shared.ts'
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -7,7 +8,5 @@ export default defineConfig({
   sourcemap: false,
   clean: true,
   treeshake: true,
-  outExtension: ({ format }) => ({
-    js: format === 'esm' ? '.mjs' : '.cjs',
-  }),
+  outExtension: outExtensionMjsCjs,
 })

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,5 +1,9 @@
-import { execSync } from 'child_process'
 import { defineConfig } from 'tsup'
+import {
+  createBaseTsupConfig,
+  createBuildDefines,
+  createOnSuccess,
+} from '../../scripts/tsup/shared.ts'
 
 const isProduction = process.env.NODE_ENV === 'production'
 const external = [
@@ -10,53 +14,7 @@ const external = [
   '@sankyu/circle-flags-core',
 ]
 
-const resolveCommit = () => {
-  const env = process.env
-  if (env.REACT_CIRCLE_FLAGS_COMMIT) return env.REACT_CIRCLE_FLAGS_COMMIT
-  if (env.GIT_COMMIT) return env.GIT_COMMIT
-
-  try {
-    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim()
-  } catch {
-    return 'dev'
-  }
-}
-
-const resolveCircleFlagsCommit = () => {
-  const env = process.env
-  if (env.REACT_CIRCLE_FLAGS_CIRCLE_FLAGS_COMMIT) return env.REACT_CIRCLE_FLAGS_CIRCLE_FLAGS_COMMIT
-
-  try {
-    return execSync('git -C ../../circle-flags rev-parse HEAD', { encoding: 'utf-8' }).trim()
-  } catch {
-    return 'unknown'
-  }
-}
-
-const resolveBuiltAt = () => {
-  const env = process.env
-  const fallback = `${Date.now()}`
-  const source = env.REACT_CIRCLE_FLAGS_BUILT_AT ?? env.BUILD_TIMESTAMP ?? env.BUILD_AT
-  const parsed = Number.parseInt(source ?? fallback, 10)
-  return Number.isFinite(parsed) ? `${parsed}` : fallback
-}
-
-const define = {
-  __REACT_CIRCLE_FLAGS_COMMIT__: JSON.stringify(resolveCommit()),
-  __REACT_CIRCLE_FLAGS_CIRCLE_FLAGS_COMMIT__: JSON.stringify(resolveCircleFlagsCommit()),
-  __REACT_CIRCLE_FLAGS_BUILT_AT__: JSON.stringify(resolveBuiltAt()),
-}
-
-const createOnSuccess = (label: string) => {
-  let buildCount = 0
-  return () => {
-    buildCount += 1
-    const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false })
-    const phase =
-      buildCount === 1 ? 'Initial build complete' : `Incremental build complete #${buildCount}`
-    console.log(`✅ ${label} ${phase} (${timestamp})`)
-  }
-}
+const define = createBuildDefines({ prefix: 'REACT_CIRCLE_FLAGS' })
 
 const applyReactJsx = (options: { jsx?: string; jsxImportSource?: string }) => {
   options.jsx = 'automatic'
@@ -67,21 +25,12 @@ const applyReactJsx = (options: { jsx?: string; jsxImportSource?: string }) => {
 export default defineConfig(options => {
   const isWatch = Boolean(options.watch)
 
-  const baseConfig = {
-    format: ['cjs', 'esm'],
-    dts: false,
-    sourcemap: false,
-    treeshake: true,
-    minify: isProduction,
-    silent: true,
+  const baseConfig = createBaseTsupConfig({
     external,
-    target: 'es2020',
-    esbuildOptions: applyReactJsx,
     define,
-    outExtension: ({ format }: { format: 'esm' | 'cjs' | string }) => ({
-      js: format === 'esm' ? '.mjs' : '.cjs',
-    }),
-  }
+    isProduction,
+    esbuildOptions: applyReactJsx,
+  })
 
   return [
     {

--- a/packages/vue/tsup.config.ts
+++ b/packages/vue/tsup.config.ts
@@ -1,76 +1,25 @@
-import { execSync } from 'child_process'
 import { defineConfig } from 'tsup'
+import {
+  createBaseTsupConfig,
+  createBuildDefines,
+  createOnSuccess,
+} from '../../scripts/tsup/shared.ts'
 
 const isProduction = process.env.NODE_ENV === 'production'
 
 const external = ['vue', '@sankyu/circle-flags-core']
 
-const resolveCommit = () => {
-  const env = process.env
-  if (env.VUE_CIRCLE_FLAGS_COMMIT) return env.VUE_CIRCLE_FLAGS_COMMIT
-  if (env.GIT_COMMIT) return env.GIT_COMMIT
-
-  try {
-    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim()
-  } catch {
-    return 'dev'
-  }
-}
-
-const resolveCircleFlagsCommit = () => {
-  const env = process.env
-  if (env.VUE_CIRCLE_FLAGS_CIRCLE_FLAGS_COMMIT) return env.VUE_CIRCLE_FLAGS_CIRCLE_FLAGS_COMMIT
-
-  try {
-    return execSync('git -C ../../circle-flags rev-parse HEAD', { encoding: 'utf-8' }).trim()
-  } catch {
-    return 'unknown'
-  }
-}
-
-const resolveBuiltAt = () => {
-  const env = process.env
-  const fallback = `${Date.now()}`
-  const source = env.VUE_CIRCLE_FLAGS_BUILT_AT ?? env.BUILD_TIMESTAMP ?? env.BUILD_AT
-  const parsed = Number.parseInt(source ?? fallback, 10)
-  return Number.isFinite(parsed) ? `${parsed}` : fallback
-}
-
-const define = {
-  __VUE_CIRCLE_FLAGS_COMMIT__: JSON.stringify(resolveCommit()),
-  __VUE_CIRCLE_FLAGS_CIRCLE_FLAGS_COMMIT__: JSON.stringify(resolveCircleFlagsCommit()),
-  __VUE_CIRCLE_FLAGS_BUILT_AT__: JSON.stringify(resolveBuiltAt()),
-}
-
-const createOnSuccess = (label: string) => {
-  let buildCount = 0
-  return () => {
-    buildCount += 1
-    const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false })
-    const phase =
-      buildCount === 1 ? 'Initial build complete' : `Incremental build complete #${buildCount}`
-    console.log(`✅ ${label} ${phase} (${timestamp})`)
-  }
-}
+const define = createBuildDefines({ prefix: 'VUE_CIRCLE_FLAGS' })
 
 // @ts-expect-error tsup options signature typing mismatch
 export default defineConfig(options => {
   const isWatch = Boolean(options.watch)
 
-  const baseConfig = {
-    format: ['cjs', 'esm'],
-    dts: false,
-    sourcemap: false,
-    treeshake: true,
-    minify: isProduction,
-    silent: true,
+  const baseConfig = createBaseTsupConfig({
     external,
-    target: 'es2020',
     define,
-    outExtension: ({ format }: { format: 'esm' | 'cjs' | string }) => ({
-      js: format === 'esm' ? '.mjs' : '.cjs',
-    }),
-  }
+    isProduction,
+  })
 
   return [
     {

--- a/scripts/tsup/shared.ts
+++ b/scripts/tsup/shared.ts
@@ -1,0 +1,89 @@
+import { execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRootDir = fileURLToPath(new URL('../..', import.meta.url))
+const circleFlagsDir = fileURLToPath(new URL('../../circle-flags', import.meta.url))
+
+const tryExec = (command: string, options?: { cwd?: string }) => {
+  try {
+    return execSync(command, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      ...options,
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+export const resolveRepoCommit = (envVarName: string) => {
+  const env = process.env
+  if (env[envVarName]) return env[envVarName]
+  if (env.GIT_COMMIT) return env.GIT_COMMIT
+  return tryExec('git rev-parse HEAD', { cwd: repoRootDir }) ?? 'dev'
+}
+
+export const resolveCircleFlagsCommit = (envVarName: string) => {
+  const env = process.env
+  if (env[envVarName]) return env[envVarName]
+  return tryExec('git rev-parse HEAD', { cwd: circleFlagsDir }) ?? 'unknown'
+}
+
+export const resolveBuiltAt = (envVarName: string) => {
+  const env = process.env
+  const fallback = `${Date.now()}`
+  const source = env[envVarName] ?? env.BUILD_TIMESTAMP ?? env.BUILD_AT
+  const parsed = Number.parseInt(source ?? fallback, 10)
+  return Number.isFinite(parsed) ? `${parsed}` : fallback
+}
+
+export const createBuildDefines = (options: { prefix: string }) => {
+  const { prefix } = options
+  const commit = resolveRepoCommit(`${prefix}_COMMIT`)
+  const circleFlagsCommit = resolveCircleFlagsCommit(`${prefix}_CIRCLE_FLAGS_COMMIT`)
+  const builtAt = resolveBuiltAt(`${prefix}_BUILT_AT`)
+
+  return {
+    [`__${prefix}_COMMIT__`]: JSON.stringify(commit),
+    [`__${prefix}_CIRCLE_FLAGS_COMMIT__`]: JSON.stringify(circleFlagsCommit),
+    [`__${prefix}_BUILT_AT__`]: JSON.stringify(builtAt),
+  } as const
+}
+
+export const createOnSuccess = (label: string) => {
+  let buildCount = 0
+  return () => {
+    buildCount += 1
+    const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false })
+    const phase =
+      buildCount === 1 ? 'Initial build complete' : `Incremental build complete #${buildCount}`
+    console.log(`✅ ${label} ${phase} (${timestamp})`)
+  }
+}
+
+export const outExtensionMjsCjs = ({ format }: { format: 'esm' | 'cjs' | string }) => ({
+  js: format === 'esm' ? '.mjs' : '.cjs',
+})
+
+export const createBaseTsupConfig = (options: {
+  external: string[]
+  define: Record<string, string>
+  isProduction: boolean
+  esbuildOptions?: (options: any) => void
+}) => {
+  const { external, define, isProduction, esbuildOptions } = options
+
+  return {
+    format: ['cjs', 'esm'],
+    dts: false,
+    sourcemap: false,
+    treeshake: true,
+    minify: isProduction,
+    silent: true,
+    external,
+    target: 'es2020',
+    define,
+    outExtension: outExtensionMjsCjs,
+    ...(esbuildOptions ? { esbuildOptions } : {}),
+  } as const
+}


### PR DESCRIPTION
Closes #32

- 提取 `scripts/tsup/shared.ts`：统一 commit/builtAt 注入、onSuccess 日志、outExtension 等
- React/Vue tsup.config.ts 仅保留各自 entry 差异
- Core 复用统一 outExtension
