### PR TITLE
fix(publish): Publish core and remove workspace protocol

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org/
 @sankyu:registry=https://registry.npmjs.org/
+link-workspace-packages=true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -46,11 +46,17 @@
         "pkgRoot": "packages/react"
       }
     ],
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "packages/core"
+      }
+    ],
     "@semantic-release/github",
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "packages/react/package.json"],
+        "assets": ["CHANGELOG.md", "packages/react/package.json", "packages/core/package.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sankyu Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@sankyu/circle-flags-core",
-  "version": "0.0.0",
-  "private": true,
+  "version": "1.5.4",
   "description": "Shared core utilities for circle-flags packages",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -15,12 +14,25 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SanKyu-Lab/circle-flags-ui.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/SanKyu-Lab/circle-flags-ui/issues"
   },
   "devDependencies": {
     "country-region-data": "^4.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sankyu/react-circle-flags",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "400+ circular SVG React flags — tree-shakeable, TypeScript-ready, SSR-compatible, zero deps.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -57,7 +57,7 @@
     "react": ">=16.0.0"
   },
   "dependencies": {
-    "@sankyu/circle-flags-core": "workspace:*"
+    "@sankyu/circle-flags-core": "^1.5.4"
   },
   "devDependencies": {
     "@babel/core": "^7.28.6",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -53,6 +53,6 @@
     "solid-js": ">=1.0.0"
   },
   "dependencies": {
-    "@sankyu/circle-flags-core": "workspace:*"
+    "@sankyu/circle-flags-core": "^1.5.4"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sankyu/vue-circle-flags",
-  "version": "0.0.2-beta",
+  "version": "0.0.3-beta",
   "description": "400+ circular SVG Vue 3 flags — tree-shakeable, TypeScript-ready, SSR-compatible, zero deps.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -56,7 +56,7 @@
     "vue": ">=3.0.0"
   },
   "dependencies": {
-    "@sankyu/circle-flags-core": "workspace:*"
+    "@sankyu/circle-flags-core": "^1.5.4"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
   packages/react:
     dependencies:
       '@sankyu/circle-flags-core':
-        specifier: workspace:*
+        specifier: ^1.5.4
         version: link:../core
     devDependencies:
       '@babel/core':
@@ -136,7 +136,7 @@ importers:
   packages/solid:
     dependencies:
       '@sankyu/circle-flags-core':
-        specifier: workspace:*
+        specifier: ^1.5.4
         version: link:../core
       solid-js:
         specifier: '>=1.0.0'
@@ -145,7 +145,7 @@ importers:
   packages/vue:
     dependencies:
       '@sankyu/circle-flags-core':
-        specifier: workspace:*
+        specifier: ^1.5.4
         version: link:../core
     devDependencies:
       '@vitest/coverage-v8':


### PR DESCRIPTION
## 背景
发布到 npm 的包里残留 `workspace:*`（并且 core 还是 private 未发布），会导致在普通项目（例如使用 Bun）安装/更新失败。

## 变更
- 将 `@sankyu/circle-flags-core` 改为可发布包（新增 `packages/core/LICENSE` 等必要文件）
- `@sankyu/react-circle-flags` / `@sankyu/vue-circle-flags` 不再使用 `workspace:*`，改为正常 semver 依赖
- bump 版本以触发 release workflow 发布（core/react 1.5.4，vue 0.0.3-beta）
- pnpm 开发体验：根 `.npmrc` 启用 `link-workspace-packages=true`

## 验证
- 已本地构建并 `pnpm pack` 验证产物中 `package.json` 不含 `workspace:` 协议

Closes #49
