### PR TITLE
fix(solid): Resolve core via tsconfig paths

### DIFF
--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -7,6 +7,11 @@
     "jsxImportSource": "solid-js",
     "strict": true,
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@sankyu/circle-flags-core": ["../core/src"],
+      "@sankyu/circle-flags-core/*": ["../core/src/*"]
+    },
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Fix Solid typecheck in clean CI by mapping @sankyu/circle-flags-core to ../core/src (same as react/vue).