### PR TITLE
fix(solid): Export `internal/escape-html` to resolve type resolution issue

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./internal/escape-html": {
+      "types": "./dist/internal/escape-html.d.ts",
+      "import": "./dist/internal/escape-html.mjs",
+      "require": "./dist/internal/escape-html.cjs"
     }
   },
   "files": [

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "paths": {
       "@sankyu/circle-flags-core": ["../core/src"],
-      "@sankyu/circle-flags-core/*": ["../core/src/*"]
+      "@sankyu/circle-flags-core/*": ["../core/src/*"],
+      "@sankyu/solid-circle-flags/*": ["src/*"]
     },
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/packages/solid/tsup.config.ts
+++ b/packages/solid/tsup.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(options => {
   return [
     {
       ...baseConfig,
-      entry: ['src/index.tsx'],
+      entry: ['src/index.tsx', 'src/internal/escape-html.ts'],
       clean: !isWatch,
       dts: true,
       format: ['esm', 'cjs'],


### PR DESCRIPTION
### Motivation
- 生成的 Solid 旗帜组件引用了子路径模块 `@sankyu/solid-circle-flags/internal/escape-html` 导致 TypeScript 报 `TS2307` 找不到模块。 
- 需要在包导出和构建配置中公开并包含该内部模块以修复运行时与类型检查路径解析。 

### Description
- 在 `packages/solid/package.json` 的 `exports` 中新增了 `./internal/escape-html` 条目以公开子路径。 
- 在 `packages/solid/tsup.config.ts` 中将 `src/internal/escape-html.ts` 加入主入口构建以确保产物中包含该模块。 
- 在 `packages/solid/tsconfig.json` 中添加了本地路径映射 `"@sankyu/solid-circle-flags/*": ["src/*"]` 以解决本地类型解析问题。 

### Testing
- 运行 `pnpm -r --filter './packages/*' --filter './website' --if-present run lint:fix` 成功通过。 
- 运行 `pnpm -r run typecheck` 未能通过，原因是 `packages/core` 缺少生成的文件导致仓库级别的类型检查失败，因此无法在此次变更中完成全量类型验证。
