### PR TITLE
feat(react): Expose per-flag subpath exports with typed declarations

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020"],

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -103,6 +103,23 @@ export default function App() {
 }
 ```
 
+### Per-flag subpath imports
+
+Each flag is also exposed as its own module under `./flags/<code>` (ISO code,
+lowercase). This guarantees only the imported flag lands in your bundle even
+when your bundler can't tree-shake the barrel (e.g. Turbopack as of Next.js 16):
+
+```tsx
+import { FlagUs } from '@sankyu/react-circle-flags/flags/us'
+import { FlagBr } from '@sankyu/react-circle-flags/flags/br'
+```
+
+> [!NOTE]
+> Named imports from the package root are equivalent under bundlers with
+> whole-barrel tree-shaking (webpack, Rollup, esbuild). Prefer subpaths when
+> you need the guarantee, or when measuring shows barrel imports bloating
+> your chunks.
+
 ### Other usage examples
 
 > [!TIP]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./flags/*": {
+      "types": "./dist/flags/*.d.ts",
+      "import": "./dist/flags/*.mjs",
+      "require": "./dist/flags/*.cjs"
     }
   },
   "files": [

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
@@ -15,6 +16,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
+    "rootDir": "../..",
     "paths": {
       "@sankyu/circle-flags-core": ["../core/src"],
       "@sankyu/circle-flags-core/*": ["../core/src/*"]

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020", "DOM"],
@@ -8,6 +9,7 @@
     "strict": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
+    "rootDir": "../..",
     "paths": {
       "@sankyu/circle-flags-core": ["../core/src"],
       "@sankyu/circle-flags-core/*": ["../core/src/*"],

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
@@ -14,6 +15,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
+    "rootDir": "../..",
     "paths": {
       "@sankyu/circle-flags-core": ["../core/src"],
       "@sankyu/circle-flags-core/*": ["../core/src/*"]

--- a/scripts/tasks/postbuild-react.mjs
+++ b/scripts/tasks/postbuild-react.mjs
@@ -26,19 +26,48 @@ export const postbuildReact = () => {
     process.exit(1)
   }
 
+  // Generate per-flag .d.ts files so the `./flags/*` subpath exports are
+  // fully typed. tsup's dts rollup produces broken chunks for the per-flag
+  // entries (see packages/react/tsup.config.ts), so declarations are emitted
+  // here from the generated sources instead. Any stray tsup-emitted .d.ts is
+  // overwritten in the process.
   try {
-    const files = readdirSync(flagsDir)
-    let removedCount = 0
+    const generatedDir = join(process.cwd(), 'generated/flags')
+    const sources = readdirSync(generatedDir).filter(f => f.endsWith('.tsx'))
+    let declared = 0
 
-    for (const file of files) {
-      if (!file.endsWith('.d.ts')) continue
-      unlinkSync(join(flagsDir, file))
-      removedCount++
+    for (const file of sources) {
+      const code = file.replace(/\.tsx$/, '')
+      const source = readFileSync(join(generatedDir, file), 'utf-8')
+
+      // Alias flags re-export their target: keep the same shape in the .d.ts
+      // so TypeScript resolves through the sibling declaration.
+      const alias = source.match(/^export \{ (\w+) as (\w+) \} from '\.\/([\w-]+)'/)
+
+      let dts
+      if (alias) {
+        dts = `export { ${alias[1]} as ${alias[2]} } from './${alias[3]}'\n`
+      } else {
+        const name = source.match(/export const (Flag\w+)/)?.[1]
+        if (!name) {
+          throw new Error(`Could not find flag export in generated/flags/${file}`)
+        }
+        dts = `import type { ReactElement, SVGProps } from 'react'
+import type { FlagComponentProps } from '@sankyu/circle-flags-core'
+export declare const ${name}: (
+  props: SVGProps<SVGSVGElement> & FlagComponentProps
+) => ReactElement
+`
+      }
+
+      writeFileSync(join(flagsDir, `${code}.d.ts`), dts, 'utf-8')
+      declared++
     }
 
-    console.log(`✅ Removed ${removedCount} redundant .d.ts files in dist/flags/`)
+    console.log(`✅ Generated ${declared} per-flag .d.ts files in dist/flags/`)
   } catch (error) {
-    console.error('⚠️  Failed to cleanup dist/flags/*.d.ts:', error)
+    console.error('❌ Failed to generate dist/flags/*.d.ts:', error)
+    process.exit(1)
   }
 
   const dctsPath = join(process.cwd(), 'dist/index.d.cts')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020"],


### PR DESCRIPTION
## Summary

Adds a `./flags/*` entry to `@sankyu/react-circle-flags`' exports map so each flag is importable as its own module:

```tsx
import { FlagBr } from '@sankyu/react-circle-flags/flags/br'
```

### Why

The per-flag bundles already exist in `dist/flags/` but aren't reachable through the exports map. Named imports from the package root rely on the bundler tree-shaking the barrel — and **Turbopack (Next.js 16's default bundler) currently can't**: a single `import { FlagBr } from '@sankyu/react-circle-flags'` bundles all ~430 flags (~400 kB minified) into the consumer's chunk. We hit this in production: the flags landed in the first load of every route of our Next.js app. Subpath imports guarantee only the imported flag ships, regardless of bundler.

### What changed

- **`packages/react/package.json`** — `"./flags/*"` exports entry (`types` + `import` + `require`)
- **`scripts/tasks/postbuild-react.mjs`** — generates a `.d.ts` per flag from the generated sources (previously this step *deleted* tsup's broken per-flag dts chunks). Component flags get a declaration mirroring the source signature; alias flags (e.g. `uk` → `gb`) re-export through the sibling declaration so TypeScript resolves the chain.
- **`packages/react/README.md`** — documents the subpath import form and when to prefer it

### Also included: TS 6 build unblock (first commit)

`main` currently fails to build/typecheck after the dependabot bump to `typescript@^6.0.3` (#143):
- every package build fails in the DTS step — tsup's dts worker injects `baseUrl`, which TS 6 rejects with `TS5101`
- react/vue/solid typecheck fails with `TS6059` (strict inferred `rootDir` vs the `../core/src` paths mapping)

The first commit fixes both (`ignoreDeprecations: "6.0"` + explicit monorepo `rootDir`, no emit effect under `noEmit`). Happy to split it into its own PR if you prefer — the feature commit depends on it to build.

## Verification

- `pnpm build:react` passes; 430 per-flag `.d.ts` generated
- ESM `import` and CJS `require` of both a component flag (`flags/br`) and an alias flag (`flags/uk`) resolve through the exports map from a consumer project
- `pnpm test:react` passes; full monorepo `pnpm typecheck` passes
- commitlint/lefthook hooks green