### PR TITLE
chore(svelte): Bump version to 0.0.1-beta.1

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sankyu/svelte-circle-flags",
-  "version": "0.0.1-beta.0",
+  "version": "0.0.1-beta.1",
   "description": "400+ circular SVG Svelte flags — tree-shakeable, TypeScript-ready, SSR-compatible, zero deps.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps `@sankyu/svelte-circle-flags` to `0.0.1-beta.1` to re-trigger the Release workflow and create the missing git tag / GitHub Release for the Svelte package.\n\n⚠️ Before merging, make sure the npm package `@sankyu/svelte-circle-flags` has been configured with this repository as a GitHub Actions Trusted Publisher (or add `NPM_TOKEN` to repository secrets and use the fallback workflow).\n\nSee the failed Release run for details: https://github.com/SanKyu-Lab/circle-flags-ui/actions/runs/27869664472