### PR TITLE
chore(example-svelte): Use svelte-circle-flags 0.0.1-beta.1

### DIFF
--- a/examples/example-svelte/package.json
+++ b/examples/example-svelte/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@sankyu/circle-flags-core": "^1.6.5",
-    "@sankyu/svelte-circle-flags": "0.0.1-beta.0",
+    "@sankyu/svelte-circle-flags": "0.0.1-beta.1",
     "@tailwindcss/vite": "^4.3.1",
     "svelte": "^5.28.6",
     "tailwindcss": "^4.3.1"

--- a/examples/example-svelte/tsconfig.json
+++ b/examples/example-svelte/tsconfig.json
@@ -17,11 +17,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
-    "paths": {
-      "@sankyu/svelte-circle-flags": ["../../packages/svelte/src/index.ts"],
-      "@sankyu/svelte-circle-flags/*": ["../../packages/svelte/src/*"]
-    }
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*.ts", "src/**/*.svelte"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
         specifier: ^1.6.5
         version: link:../../packages/core
       '@sankyu/svelte-circle-flags':
-        specifier: 0.0.1-beta.0
+        specifier: 0.0.1-beta.1
         version: link:../../packages/svelte
       '@tailwindcss/vite':
         specifier: ^4.3.1


### PR DESCRIPTION
Updates the Svelte example to use the newly published `@sankyu/svelte-circle-flags@0.0.1-beta.1` and removes the workspace path aliases from `tsconfig.json` so it resolves the package from npm like the other framework examples.