### PR TITLE
docs(svelte): Align README with other packages

### DIFF
--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,10 +1,57 @@
+<div align="center">
+  <a href="https://react-circle-flags.js.org/">
+    <img src="https://raw.githubusercontent.com/SanKyu-Lab/circle-flags-ui/main/.github/assets/favicon.svg" alt="@sankyu/svelte-circle-flags" width="120" height="120" />
+  </a>
+</div>
+
+<div align="center">
+
 # @sankyu/svelte-circle-flags
 
-> **Beta release** — APIs may evolve until v1.0.0.
+[![npm version](https://img.shields.io/npm/v/%40sankyu%2Fsvelte-circle-flags?style=flat-square&label=%40sankyu%2Fsvelte-circle-flags)](https://www.npmjs.com/package/@sankyu/svelte-circle-flags) [![Bundle Size](https://img.shields.io/bundlephobia/minzip/@sankyu/svelte-circle-flags?style=flat-square&label=Bundle%20Size)](https://bundlephobia.com/package/@sankyu/svelte-circle-flags) [![npm downloads](https://img.shields.io/npm/dm/@sankyu/svelte-circle-flags.svg?style=flat-square&label=NPM%20Downloads)](https://www.npmjs.com/package/@sankyu/svelte-circle-flags) [![Last Commit](https://img.shields.io/github/last-commit/SanKyu-Lab/circle-flags-ui?style=flat-square&label=Last%20Commit)](https://github.com/SanKyu-Lab/circle-flags-ui/commits/main)
 
-400+ circular SVG Svelte flags — tree-shakeable, TypeScript-ready, SSR-compatible, zero deps.
+<!-- CI/CD & Quality -->
 
-## Installation
+[![CI](https://github.com/SanKyu-Lab/circle-flags-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/SanKyu-Lab/circle-flags-ui/actions/workflows/ci.yml) [![Release](https://github.com/SanKyu-Lab/circle-flags-ui/actions/workflows/release.yml/badge.svg)](https://github.com/SanKyu-Lab/circle-flags-ui/actions/workflows/release.yml) [![codecov](https://codecov.io/gh/SanKyu-Lab/circle-flags-ui/branch/main/graph/badge.svg)](https://codecov.io/gh/SanKyu-Lab/circle-flags-ui)
+
+[![TypeScript supported](https://img.shields.io/badge/TypeScript-supported-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org/) [![Tree-shakable](https://badgen.net/bundlephobia/tree-shaking/@sankyu/svelte-circle-flags)](https://bundlephobia.com/package/@sankyu/svelte-circle-flags) [![MIT License](https://img.shields.io/badge/License-MIT-green?style=flat-square&logo=opensourceinitiative)](./LICENSE)
+
+---
+
+:star: **Star us on [GitHub](https://github.com/Sankyu-Lab/circle-flags-ui)** | :bug: **Report Issues [here](https://github.com/Sankyu-Lab/circle-flags-ui/issues)**
+
+:rocket: **Explore the [Demo Gallery](https://react-circle-flags.js.org/browse)** | :book: **Read the [Documentation](https://react-circle-flags.js.org/docs/guides/getting-started/)**
+
+</div>
+
+---
+
+> [!NOTE]
+> 🚧 **Beta Release**
+>
+> This package is currently in beta. APIs may change in future releases. Please report any issues you encounter!
+
+## 📖 Overview
+
+This library provides **400+ circular SVG flag components** for **Svelte 5** with **Full-TypeScript support** & **Tree-shaking Optimization**.
+
+Perfect for applications that need fast, crisp country flags without external image requests.
+
+## :world_map: Live Demo
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/SanKyu-Lab/circle-flags-ui/tree/main/examples/example-svelte?file=src%2FApp.svelte&terminal=dev)
+
+## ✨ Key Features
+
+- 🎯 **Tree-shakable** - Only bundle the flags you use
+- 📦 **TypeScript** - Full type definitions included
+- ⚡ **Zero dependencies** - Only requires Svelte 5 as peer dependency
+- 🎨 **Inline SVG** - No external requests, works offline
+- 🔧 **Fully customizable** - All standard SVG props supported
+- 📱 **SSR compatible** - Works with **SvelteKit** and other SSR setups
+- 🪶 **Lightweight** - Each flag is ~1KB
+
+## 📦 Installation
 
 ```bash
 npm install @sankyu/svelte-circle-flags
@@ -12,27 +59,93 @@ npm install @sankyu/svelte-circle-flags
 pnpm add @sankyu/svelte-circle-flags
 # or
 yarn add @sankyu/svelte-circle-flags
+# or
+bun add @sankyu/svelte-circle-flags
 ```
 
-`@sankyu/svelte-circle-flags` has a single peer dependency:
+> [!TIP]
+> For more information, you may refer to the [Installation Guide](https://react-circle-flags.js.org/docs/guides/getting-started/installation/).
+
+### Peer dependency
 
 ```bash
 npm install svelte@^5.0.0
 ```
 
-## Usage
+### 🤖 Are you Vibe Coding?
 
-Import named flag components directly. Only the flags you import are bundled.
+Copy this into your AI Agent (Claude Code, Codex, Cursor ..like) to optimize your flags:
+
+<details>
+<summary>AI Agent Prompts</summary>
+
+```txt
+Act as an expert Web Engineer. Reference: https://react-circle-flags.js.org/llms.txt & https://react-circle-flags.js.org/llms-small.txt
+
+1. **Audit my project** to find any flag usage:
+   - Raw `<img>` tags pointing to `HatScripts/circle-flags` URLs.
+   - Legacy `react-circle-flags` library usage.
+2. **Propose a migration** to the appropriate `@sankyu/{framework}-circle-flags` package based on my current framework (React/Vue/Solid/Svelte).
+3. **Optimize for Tree-shaking**: Replace generic `CircleFlag` components or raw tags with **named imports** (e.g., `import { FlagUs } from '...'`) as per the docs.
+```
+
+</details>
+
+## 🚀 Usage
+
+### Import individual flags (Recommended)
 
 ```svelte
 <script>
   import { FlagUs, FlagCn, FlagGb } from '@sankyu/svelte-circle-flags'
 </script>
 
-<FlagUs width={64} height={64} class="flag-icon" />
-<FlagCn width={64} height={64} className="flag-icon" />
-<FlagGb width={64} height={64} />
+<div>
+  <FlagUs width={48} height={48} />
+  <FlagCn width={48} height={48} />
+  <FlagGb width={48} height={48} />
+</div>
 ```
+
+### Using `FlagSizes` presets
+
+```svelte
+<script>
+  import { FlagJp, FlagDe, FlagFr, FlagSizes } from '@sankyu/svelte-circle-flags'
+</script>
+
+<div>
+  <FlagJp width={FlagSizes.sm} height={FlagSizes.sm} />
+  <!-- 24px -->
+  <FlagDe width={FlagSizes.md} height={FlagSizes.md} />
+  <!-- 32px -->
+  <FlagFr width={FlagSizes.lg} height={FlagSizes.lg} />
+  <!-- 48px -->
+</div>
+```
+
+### Dynamic flag selection
+
+```svelte
+<script>
+  import { DynamicFlag } from '@sankyu/svelte-circle-flags'
+
+  let countryCode = $state('us')
+</script>
+
+<select bind:value={countryCode}>
+  <option value="us">United States</option>
+  <option value="cn">China</option>
+  <option value="gb">United Kingdom</option>
+</select>
+
+<DynamicFlag code={countryCode} width={48} height={48} />
+```
+
+> [!CAUTION]
+> `DynamicFlag` is offline-first and renders runtime codes synchronously, but it bundles all
+> 400+ flags (~600 KB, no tree-shaking). Prefer named imports when possible. If runtime codes
+> are bounded, use a finite named-import map.
 
 ### Deep imports
 
@@ -43,80 +156,122 @@ You can also import individual flags directly. This is useful for dynamic import
   import FlagUs from '@sankyu/svelte-circle-flags/flags/us'
 </script>
 
-<FlagUs width={64} height={64} />
+<FlagUs width={48} height={48} />
 ```
 
-## Dynamic flag
+## ⚠️ Deprecated: `CircleFlag`
 
-Use `DynamicFlag` when the country code is only known at runtime:
+`CircleFlag` is deprecated and is **not recommended for new code**.
 
-```svelte
-<script>
-  import { DynamicFlag } from '@sankyu/svelte-circle-flags'
+- It fetches SVG at runtime (not offline-first).
+- After loading, it renders a wrapper with injected SVG HTML, so many SVG-only props won’t apply.
 
-  let code = $state('us')
-</script>
+Prefer named imports or `DynamicFlag` instead.
 
-<select bind:value={code}>
-  <option value="us">United States</option>
-  <option value="cn">China</option>
-  <option value="gb">United Kingdom</option>
-</select>
+## 📚 API
 
-<DynamicFlag {code} width={64} height={64} />
-```
-
-`DynamicFlag` accepts a `strict` prop. When `strict={true}`, invalid codes render a fallback `FlagXx` placeholder instead of attempting coercion.
-
-## CircleFlag (deprecated)
-
-`CircleFlag` fetches SVG from a CDN at runtime. It is kept for compatibility but is **not recommended for new code**.
-
-```svelte
-<script>
-  import { CircleFlag } from '@sankyu/svelte-circle-flags'
-</script>
-
-<CircleFlag countryCode="us" width={64} height={64} />
-```
-
-Prefer named imports or `DynamicFlag` for better tree-shaking and offline support.
-
-## Props
-
-All flag components accept standard SVG attributes plus:
+### Props
 
 | Prop        | Type               | Default | Description                                |
 | ----------- | ------------------ | ------- | ------------------------------------------ |
-| `width`     | `number \| string` | `48`    | Rendered width                             |
-| `height`    | `number \| string` | `48`    | Rendered height                            |
-| `class`     | `string`           | —       | CSS class (Svelte convention)              |
-| `className` | `string`           | —       | CSS class alias for cross-framework habits |
-| `title`     | `string`           | code    | Accessible `<title>` text                  |
+| `width`     | `number \| string` | `48`    | Width of the flag                          |
+| `height`    | `number \| string` | `48`    | Height of the flag                         |
+| `title`     | `string`           | code    | Accessible title for the SVG               |
+| `class`     | `string`           | -       | Standard Svelte class binding              |
+| `className` | `string`           | -       | Optional className alias                   |
 
-## Utilities
+### Size Presets
+
+| Size   | Pixels |
+| ------ | ------ |
+| `xs`   | 16px   |
+| `sm`   | 24px   |
+| `md`   | 32px   |
+| `lg`   | 48px   |
+| `xl`   | 64px   |
+| `xxl`  | 96px   |
+| `xxxl` | 128px  |
+
+### Build Meta Information
+
+You can access the library's build meta information from the `buildMeta` export:
 
 ```svelte
 <script>
-  import { FLAG_REGISTRY, FlagUtils } from '@sankyu/svelte-circle-flags'
+  import { buildMeta } from '@sankyu/svelte-circle-flags'
 
-  const isValid = FlagUtils.isValidCountryCode('us')
-  const allCodes = Object.keys(FLAG_REGISTRY)
+  console.log(buildMeta.version) // e.g., "0.0.1-beta.1"
+  console.log(buildMeta.builtTimestamp) // e.g., 1760000000000
+  console.log(buildMeta.commitHash) // e.g., <example-sha256-hash>
+  console.log(buildMeta.circleFlagsCommitHash) // e.g., <example-sha256-hash>
 </script>
 ```
 
-## TypeScript
+### Available Flags
 
-`FlagCode` and `CountryCode` are exported from the core registry:
+Each flag is exported with the pattern `Flag{PascalCase ISO_CODE}` (for example, `FlagUs`, `FlagCn`). Convenience aliases are provided for common two-letter codes: `FlagUs`, `FlagCn`, `FlagGb`, `FlagJp`.
 
-```ts
-import type { FlagCode, CountryCode } from '@sankyu/svelte-circle-flags'
+- `FlagUs` - United States
+- `FlagCn` - China
+- `FlagGb` - United Kingdom
+- `FlagJp` - Japan
+- ... and many more
+
+See the [Full list of flags](https://react-circle-flags.js.org/browse) in the gallery.
+
+## 🎨 Styling
+
+Flag components accept all standard SVG attributes and can be styled using Svelte's class binding.
+
+```svelte
+<script>
+  import { FlagUs } from '@sankyu/svelte-circle-flags'
+</script>
+
+<!-- Using class -->
+<FlagUs class="rounded-full shadow-lg hover:scale-110 transition-transform" />
+
+<!-- Using inline styles -->
+<FlagUs style="filter: grayscale(100%)" />
+
+<!-- With custom attributes -->
+<FlagUs aria-label="United States flag" role="img" />
 ```
 
-## SSR
+## 🔧 TypeScript
 
-This package ships preprocessed `.svelte` source files and is fully compatible with SvelteKit and other server-side rendering setups.
+All flag components are fully typed with TypeScript, providing autocomplete and type safety out of the box.
 
-## License
+```typescript
+import type { FlagComponentProps, FlagCode } from '@sankyu/svelte-circle-flags'
 
-MIT © [Sankyu Lab](https://github.com/SanKyu-Lab)
+// FlagCode is a union type of all valid flag codes
+const code: FlagCode = 'us' // ✓ Valid
+const invalid: FlagCode = 'xyz' // ✗ Type error
+```
+
+## 📦 Bundle Size & Tree-shaking
+
+`@sankyu/svelte-circle-flags` is designed to be tree-shakable.
+
+Importing individual flags ensures that only the used flags are included in your bundle.
+
+```svelte
+<script>
+  // ✓ Good - only FlagUs and FlagCn are bundled
+  import { FlagUs, FlagCn } from '@sankyu/svelte-circle-flags'
+</script>
+```
+
+## 🤝 Contributing
+
+Please see [CONTRIBUTING.md](https://github.com/Sankyu-Lab/circle-flags-ui/blob/main/CONTRIBUTING.md) for contribution guidelines.
+
+## 📄 License
+
+`@sankyu/svelte-circle-flags` is licensed under the MIT License, © [Sankyu Lab](https://github.com/Sankyu-Lab)
+
+## 🙏 Credits
+
+- Flag designs from [HatScripts/circle-flags](https://github.com/HatScripts/circle-flags)
+- Built with [@sveltejs/package](https://github.com/sveltejs/package)

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -36,3 +36,5 @@ export type CountryCode = FlagCode
 export * from './flags'
 
 export { FLAG_REGISTRY, coerceFlagCode, isFlagCode, type FlagCode } from '@sankyu/circle-flags-core'
+
+export type { FlagComponentProps } from '@sankyu/circle-flags-core'


### PR DESCRIPTION
Reworks `packages/svelte/README.md` to match the structure and detail level of the React/Vue/Solid package READMEs:\n\n- Header with favicon, npm/bundle/CI badges, and doc links\n- Beta release notice\n- Overview, live demo, key features, installation (incl. peer dependency)\n- AI Agent prompt block\n- Usage examples for named imports, `FlagSizes`, `DynamicFlag`, and deep imports\n- Deprecated `CircleFlag` callout\n- API tables for props and size presets\n- Build meta, available flags, styling, TypeScript, bundle size sections\n- Contributing, license, credits\n\nAlso exports `FlagComponentProps` from `packages/svelte/src/index.ts` so the README's TypeScript example is accurate.