### PR TITLE
fix(svelte): Silence baseUrl TS5101 deprecation with ignoreDeprecations

### DIFF
--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "rootDir": "..",
     "paths": {
       "@sankyu/circle-flags-core": ["../core/src"],

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,11 +3,19 @@ import { defineConfig, fontProviders } from 'astro/config'
 import react from '@astrojs/react'
 import starlight from '@astrojs/starlight'
 import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
 import { siteConfig } from './src/config/siteConfig'
 import starlightLlmsTxt from 'starlight-llms-txt'
 import starlightTypeDoc from 'starlight-typedoc'
 import starlightAutoSidebar from 'starlight-auto-sidebar'
 import starlightLinksValidator from 'starlight-links-validator'
+
+const require = createRequire(import.meta.url)
+// starlight-links-validator is incompatible with Astro 7's markdown processor
+// (https://github.com/HiDeoo/starlight-links-validator/issues/165). Skip it until
+// upstream ships an Astro 7-compatible release, then remove this gate.
+const astroMajorVersion = Number.parseInt(require('astro/package.json').version, 10)
+const supportsLinkValidator = astroMajorVersion < 7
 
 const isAstroCheck = process.argv.includes('check')
 const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true'
@@ -22,7 +30,7 @@ const corePkgSrcDir = fileURLToPath(new URL('../packages/core/src/', import.meta
 
 const starlightPlugins = [
   starlightAutoSidebar(),
-  ...(!isAstroCheck
+  ...(!isAstroCheck && supportsLinkValidator
     ? [
         starlightLinksValidator({
           errorOnFallbackPages: false,


### PR DESCRIPTION
## Summary

Fixes **all** failing PR Checks that were blocking every open Dependabot PR. Two independent root causes; both fixed here.

## 1. Svelte build/typecheck — `TS5101` baseUrl deprecation

TypeScript now emits `TS5101` for the deprecated `baseUrl` compiler option:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption "ignoreDeprecations": "6.0" to silence this error.
```

`svelte-preprocess` treats that diagnostic as fatal, breaking the svelte build and `svelte-check` and cascading to the **Build** and **Tests** jobs.

`packages/svelte/tsconfig.json` was the **only** package tsconfig missing `"ignoreDeprecations": "6.0"` — `core`, `react`, `solid`, `vue`, `website` already had it.

**Fix:** add `"ignoreDeprecations": "6.0"` to `packages/svelte/tsconfig.json`.

## 2. Website lint — Astro 7 / starlight-links-validator incompatibility

The **Lint + Typecheck** job failed in `website#lint`:

```
[AstroUserError] The configured 'markdown.processor' is not supported.
Switch to 'unified()' from '@astrojs/markdown-remark'.
  at starlight-links-validator .../index.ts:129
```

PR #167 bumped Astro 6.4.8 → 7.0.2. `starlight-links-validator@0.24.1` (latest) is not Astro 7-compatible — upstream issue [#165](https://github.com/HiDeoo/starlight-links-validator/issues/165) is open with no fix released.

**Fix:** detect the Astro major version in `astro.config.mjs` and skip `starlight-links-validator` on Astro ≥ 7. Link validation returns automatically once upstream ships an Astro 7-compatible release.

## Verification (Node 22.x, matching CI)

- ✅ `svelte-check` → **0 errors, 0 warnings**
- ✅ CI `build` (`turbo build --filter='./packages/*'`) → 5/5 packages, all dist dirs present
- ✅ CI `lint-typecheck` (turbo `lint typecheck`) → all packages + **website** pass
- ✅ All 4 PR Checks jobs **green** (Build / Format / Tests / Lint + Typecheck)

## 举一反三 (generalization)

- Audited every `tsconfig.json`. All package + website tsconfigs now consistently set `"ignoreDeprecations": "6.0"`.
- `examples/*/tsconfig*.json` also use `baseUrl`, but examples are outside CI's `build`/`typecheck` scope (`run-checks.mjs` only builds `./packages/*`), so they don't block CI.
- Opened dependabot PRs will go green again once this merges to `main` and they re-run checks.

## Out of scope (not addressed — flagged for awareness)
- `scripts/tasks/postbuild-svelte.mjs:100` uses `fs.rmdirSync(path, { recursive: true })`, deprecated as a **warning** on Node 22 (CI) but fatal on Node ≥ 25. Switching to `fs.rmSync(path, { recursive: true })` is a proactive improvement, not a current CI failure.